### PR TITLE
AP Gain and Yield on Farms Page broken before datacubes

### DIFF
--- a/AcademyPortal.js
+++ b/AcademyPortal.js
@@ -248,7 +248,9 @@ function CalculateFarmYields(giveTotal = false)
     staticAPbonus *= (0.5 * (playerData.academy.gearSets[3] === 5) + 1);
     staticAPbonus *= (0.5 * (playerData.academy.gearSets[4] === 5) + 1);
     staticAPbonus *= Math.pow(1.25, playerData.academy.projectLevels[5]);
-    staticAPbonus *= playerData.academy.exchanges.dataCubes * 0.005 * Math.pow(1.25, playerData.loopMods.exodus) * Math.pow(1.5, playerData.loopMods.allExchange) * Math.pow(1.1, Math.floor(playerData.academy.exchanges.dataCubes / 100));
+    if(playerData.academy.exchanges.dataCubes){
+        staticAPbonus *= playerData.academy.exchanges.dataCubes * 0.005 * Math.pow(1.25, playerData.loopMods.exodus) * Math.pow(1.5, playerData.loopMods.allExchange) * Math.pow(1.1, Math.floor(playerData.academy.exchanges.dataCubes / 100));
+    }
     staticAPbonus *= Math.pow(1.05, playerData.diamonds.special.ap);
     staticAPbonus *= 0.18 * playerData.diamonds.cards.nora + 1;
     staticAPbonus *= 0.4 * playerData.diamonds.cards.omega + 1;


### PR DESCRIPTION
added in a check for datacubes to prevent multiplying staticAPbonus by 0 so AP gain rate and yield is available pre data cubes, I've also attached some screenshots to show the problem before and after the fix, i can also attach the save file im using if that helps the PR 

![Screenshot 2023-06-10 145114](https://github.com/sirrebrl/CIFIsuper/assets/45927891/d112e9cb-ab7d-4870-9d90-cb91bfd6cb25)

![Screenshot 2023-06-10 145138](https://github.com/sirrebrl/CIFIsuper/assets/45927891/8d2951ba-a40a-477a-a2db-7b0e3a33ee86)